### PR TITLE
Temporary, inefficient recv_into.

### DIFF
--- a/backports/ssl/core.py
+++ b/backports/ssl/core.py
@@ -262,6 +262,17 @@ class SSLSocket(object):
         return _safe_ssl_call(self._suppress_ragged_eofs, self._conn, 'recv',
                                bufsize, flags)
 
+    def recv_into(self, buffer, bufsize=None, flags=None):
+        # A temporary recv_into implementation. Should be replaced when
+        # PyOpenSSL has merged pyca/pyopenssl#121.
+        if bufsize is None:
+            bufsize = len(buffer)
+
+        data = self.recv(bufsize, flags)
+        data_len = len(data)
+        buffer[0:data_len] = data
+        return data_len
+
     def send(self, data, flags=None):
         return _safe_ssl_call(False, self._conn, 'send', data, flags)
 


### PR DESCRIPTION
As tracked in Lukasa/hyper#59, `hyper` needs support for `recv_into`. PyOpenSSL doesn't have it yet. I've opened a pull request for proper support (pyca/pyopenssl#121), but until that gets merged this provides a ghetto form of support for it.

No need to rush a release including this yet, `hyper` is still using its bundled copy of `backports.ssl`, though I plan to start depending on this repo in a future release. =)
