### PR TITLE
Exposing socket.gettimeout and socket.read

### DIFF
--- a/backports/ssl/core.py
+++ b/backports/ssl/core.py
@@ -337,7 +337,7 @@ class SSLSocket(object):
 
     # a dash of magic to reduce boilerplate
     for method in ['accept', 'bind', 'close', 'fileno', 'getsockname', 'listen',
-                   'setblocking', 'settimeout']:
+                   'setblocking', 'settimeout', 'gettimeout']:
         locals()[method] = _proxy(method)
 
 

--- a/backports/ssl/core.py
+++ b/backports/ssl/core.py
@@ -337,7 +337,7 @@ class SSLSocket(object):
 
     # a dash of magic to reduce boilerplate
     for method in ['accept', 'bind', 'close', 'fileno', 'getsockname', 'listen',
-                   'setblocking', 'settimeout', 'gettimeout']:
+                   'setblocking', 'settimeout', 'gettimeout', 'read']:
         locals()[method] = _proxy(method)
 
 


### PR DESCRIPTION
Heya, I think socket.gettimeout and socket.read also need to be exposed as they are part of the method proxy