### PR TITLE
Limit the maximum recv buffer size in read()

### DIFF
--- a/backports/ssl/core.py
+++ b/backports/ssl/core.py
@@ -478,7 +478,13 @@ class _fileobject(object):
                 # than that.  The returned data string is short lived
                 # as we copy it into a BytesIO and free it.  This avoids
                 # fragmentation issues on many platforms.
-                data = _safe_ssl_call(False, self._sock, 'recv', left)
+
+                # Note: never pass a large value as the maximum size
+                # to pyOpenSSL's recv because it will always allocate
+                # a buffer that size but then return a much smaller
+                # number buffer (typically 1024 bytes). This causes
+                # severe performance problems when `size` is large.
+                data = _safe_ssl_call(False, self._sock, 'recv', rbufsize)
                 if not data:
                     break
                 n = len(data)


### PR DESCRIPTION
`rbufsize` is now used as the maximum size to with recv instead of `left` because pyOpenSSL's recv typically reads just a small amount of data (1KB observed) and returns immediately.

Even though it only returns a small amount of data each call, recv still allocates a buffer of the requested size, which was causing signficant performance problems when `size` - and therefore `left` - is large. recv is called many times and each call was making time consuming allocations of large buffers.

Using a small size with the recv calls doesn't change the number of calls to recv but ensures each call is not making unnecessarily large memory allocations.
