### PR TITLE
Avoid reading more bytes than requested

### DIFF
--- a/backports/ssl/core.py
+++ b/backports/ssl/core.py
@@ -484,7 +484,8 @@ class _fileobject(object):
                 # a buffer that size but then return a much smaller
                 # number buffer (typically 1024 bytes). This causes
                 # severe performance problems when `size` is large.
-                data = _safe_ssl_call(False, self._sock, 'recv', rbufsize)
+                maxbufsize = min(rbufsize, left)
+                data = _safe_ssl_call(False, self._sock, 'recv', maxbufsize)
                 if not data:
                     break
                 n = len(data)


### PR DESCRIPTION
The recent change to limit the read buffer size used with recv neglected to handle the case of `left` being smaller than `rbufsize`.