### PR TITLE
Include the license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,7 @@
+# License files
 include LICENSE
+include CONTRIBUTORS.rst
+include NOTICES.rst
+
+# Docs
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     author_email='alek.storm@gmail.com',
     url='https://github.com/alekstorm/backports.ssl',
     packages=['backports', 'backports.ssl'],
-    package_data={'': ['CONTRIBUTORS.rst', 'LICENSE', 'NOTICES.rst', 'README.rst']},
     include_package_data=True,
     license='MIT',
     classifiers=[


### PR DESCRIPTION
Adds the license to `MANIFEST.in` so as to include the license in packages list `sdist`s.

cc @pmlandwehr
